### PR TITLE
Add "plugin" namespace to rule

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,6 +1,6 @@
 const assign = require('object-assign');
 const stylelint = require('stylelint');
-const ruleName = 'property-unknown';
+const ruleName = 'plugin/property-unknown';
 const knownProperties = require('./data/knownProperties');
 const messages = stylelint.utils.ruleMessages(ruleName, {
   rejected: 'Property is unknown',


### PR DESCRIPTION
Fixes stylelint deprecation warning: "Plugin rules that aren't namespaced have been deprecated, and in 7.0 they will be disallowed"
